### PR TITLE
Window layout improvements and individual search

### DIFF
--- a/MusicBeeSyncToService/Models/MusicBeeSong.cs
+++ b/MusicBeeSyncToService/Models/MusicBeeSong.cs
@@ -11,11 +11,17 @@ namespace MusicBeePlugin.Models
         public String Artist;
         public String Title;
         public String Album;
-
+        
         public override string ToString()
         {
             return Artist + " - " + Title;
         }
 
+    }
+
+    public class MusicBeeSongSearch
+    {
+        public MusicBeeSong Song { get; set; }
+        public int SearchScore { get; set; }
     }
 }

--- a/MusicBeeSyncToService/Models/PopulatedSong.cs
+++ b/MusicBeeSyncToService/Models/PopulatedSong.cs
@@ -1,0 +1,113 @@
+﻿using SpotifyAPI.Web;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicBeePlugin.Models
+{
+    public class PopulatedSong
+    {
+        public MusicBeeSong MbSong { get; set; }
+        public FullTrack SpotifySong { get; set; }
+        
+        private bool checkedValue = false;
+        public bool Checked 
+        {
+            get => checkedValue;
+            set
+            {
+                if ((MbSong == null) || (SpotifySong == null))
+                    checkedValue = false;
+                else
+                    checkedValue = value;
+            }
+        }
+
+        public string MbSongDisplayName
+        {
+            get
+            {
+                if (MbSong == null)
+                    return "";
+                return MbSong.Artist + " - " + MbSong.Title;
+            }
+        }
+
+        public string SpotifySongDisplayName
+        {
+            get
+            {
+                if (SpotifySong == null)
+                    return "";
+                return String.Join(", ", SpotifySong.Artists.Select(a => a.Name)) + " - " + SpotifySong.Name;
+            }
+        }
+    }
+
+
+    public static class PopulatedSongsForDesign
+    {
+        public static PopulatedSong[] Songs
+        {
+            get
+            {
+                return new PopulatedSong[]
+                {
+                    new PopulatedSong()
+                    {
+                        MbSong = new MusicBeeSong()
+                        {
+                            Artist = "Artist 1",
+                            Title = "Title 1",
+                            Album = "Album 1"
+                        },
+                        SpotifySong = new FullTrack()
+                        {
+                            Name = "Title 1",
+                            Artists = new List<SimpleArtist>()
+                            {
+                                new SimpleArtist() { Name = "Artist 1" }
+                            }
+                        }
+                    },
+                    new PopulatedSong()
+                    {
+                        MbSong = new MusicBeeSong()
+                        {
+                            Artist = "Artist 2",
+                            Title = "Title 2",
+                            Album = "Album 2"
+                        },
+                        SpotifySong = new FullTrack()
+                        {
+                            Name = "Title 2",
+                            Artists = new List<SimpleArtist>()
+                            {
+                                new SimpleArtist() { Name = "Artist 2" }
+                            }
+                        }
+                    },
+                    new PopulatedSong()
+                    {
+                        MbSong = new MusicBeeSong()
+                        {
+                            Artist = "Artist 3",
+                            Title = "Title 3 with long name to test how wrap will work with the exceeding words",
+                            Album = "Album 3"
+                        },
+                        SpotifySong = new FullTrack()
+                        {
+                            Name = "Title 3 with long name to test how wrap will work with the exceeding words",
+                            Artists = new List<SimpleArtist>()
+                            {
+                                new SimpleArtist() { Name = "Artist 3" }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/MusicBeeSyncToService/Models/PopulatedSong.cs
+++ b/MusicBeeSyncToService/Models/PopulatedSong.cs
@@ -41,7 +41,7 @@ namespace MusicBeePlugin.Models
             {
                 if (SpotifySong == null)
                     return "";
-                return String.Join(", ", SpotifySong.Artists.Select(a => a.Name)) + " - " + SpotifySong.Name;
+                return String.Join("; ", SpotifySong.Artists.Select(a => a.Name)) + " - " + SpotifySong.Name;
             }
         }
     }

--- a/MusicBeeSyncToService/MusicBeeSyncToService.csproj
+++ b/MusicBeeSyncToService/MusicBeeSyncToService.csproj
@@ -103,6 +103,7 @@
     <Compile Include="MusicBeePlugin\MBGmusicPlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WPF\CheckedListItem.cs" />
+    <Compile Include="WPF\FullTrackStringConverter.cs" />
     <Compile Include="WPF\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Compile>

--- a/MusicBeeSyncToService/MusicBeeSyncToService.csproj
+++ b/MusicBeeSyncToService/MusicBeeSyncToService.csproj
@@ -87,6 +87,7 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\PlaylistSyncError.cs" />

--- a/MusicBeeSyncToService/MusicBeeSyncToService.csproj
+++ b/MusicBeeSyncToService/MusicBeeSyncToService.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Models\PlaylistSyncError.cs" />
     <Compile Include="Models\MusicBeePlaylist.cs" />
     <Compile Include="Models\MusicBeeSong.cs" />
+    <Compile Include="Models\PopulatedSong.cs" />
     <Compile Include="Models\SpotifyPlaylist.cs" />
     <Compile Include="Models\SyncToSpotifySettings.cs" />
     <Compile Include="Services\MusicBeeSyncHelper.cs" />

--- a/MusicBeeSyncToService/Services/MusicBeeSyncHelper.cs
+++ b/MusicBeeSyncToService/Services/MusicBeeSyncHelper.cs
@@ -150,7 +150,7 @@ namespace MusicBeePlugin.Services
                         SearchScore = score
                     };
                 })
-                .Where(s => s.SearchScore > wordsCount) //minimum score should match the number of words for album
+                .Where(s => s.SearchScore > (wordsCount * 5)) //minimum score should match the number of words for artist at least
                 .OrderByDescending(s => s.SearchScore)
                 .Take(10)
                 .ToList();

--- a/MusicBeeSyncToService/Services/MusicBeeSyncHelper.cs
+++ b/MusicBeeSyncToService/Services/MusicBeeSyncHelper.cs
@@ -112,5 +112,48 @@ namespace MusicBeePlugin.Services
             return allMbSongs;
         }
 
+
+        public IEnumerable<MusicBeeSongSearch> FindSongsByWords(params string[] words)
+        {
+            int wordsCount = words.Length;
+
+            if (words == null || wordsCount == 0)
+                return new List<MusicBeeSongSearch>(0);
+
+            return Songs
+                .Select(s =>
+                {
+                    int score = 0;
+                    var title = s.Title.ToLower();
+                    var artist = s.Artist.ToLower();
+                    var album = s.Album.ToLower();
+
+                    foreach (var word in words)
+                    {
+                        if (title.Contains(word))
+                        {
+                            score += 10;
+                        }
+                        if (artist.Contains(word))
+                        {
+                            score += 5;
+                        }
+                        if (album.Contains(word))
+                        {
+                            score += 1;
+                        }
+                    }
+
+                    return new MusicBeeSongSearch
+                    {
+                        Song = s,
+                        SearchScore = score
+                    };
+                })
+                .Where(s => s.SearchScore > wordsCount) //minimum score should match the number of words for album
+                .OrderByDescending(s => s.SearchScore)
+                .Take(10)
+                .ToList();
+        }
     }
 }

--- a/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
+++ b/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Documents;
+using static Swan.Terminal;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.StartPanel;
 
 namespace MusicBeePlugin.Services
@@ -91,130 +92,18 @@ namespace MusicBeePlugin.Services
             return Playlists;
         }
 
-        public async Task<List<IPlaylistSyncError>> SyncToSpotify(MusicBeeSyncHelper mb, List<MusicBeePlaylist> mbPlaylistsToSync,
+        public async Task SyncToSpotify(List<MusicBeePlaylist> mbPlaylistsToSync,
             SyncToSpotifySettings settings)
         {
-            List<IPlaylistSyncError> errors = new List<IPlaylistSyncError>();
+            PopulateErrors.Clear();
 
             foreach (MusicBeePlaylist playlist in mbPlaylistsToSync)
             {
-                // Use LINQ to check for a playlist with the same name
-                // If there is one, clear it's contents, otherwise create one
-                // Unless it's been deleted, in which case pretend it doesn't exist.
-                // I'm not sure how to undelete a playlist, or even if you can
-                string spotifyPlaylistName = null;
-                if (settings.IncludeFoldersInPlaylistName)
-                {
-                    spotifyPlaylistName = playlist.Name;
-                }
-                else
-                {
-                    spotifyPlaylistName = playlist.Name.Split('\\').Last();
-                }
+                PopulateMusicBeePlaylist = playlist;
+                await PopulateSpotifyPlaylistSongsFromMbPlaylist(false);
 
-                if (settings.IncludeZAtStartOfDatePlaylistName)
-                {
-                    // if it starts with a 2, it's a date playlist
-                    if (spotifyPlaylistName.StartsWith("2"))
-                    {
-                        spotifyPlaylistName = $"Z {spotifyPlaylistName}";
-                    }
-                }
-
-                // If Spotify playlist with same name already exists, clear it.
-                // Otherwise create one
-                SimplePlaylist thisPlaylist = Playlists.FirstOrDefault(p => p.Name == spotifyPlaylistName);
-                string thisPlaylistId;
-                if (thisPlaylist != null)
-                {
-                    var request = new PlaylistReplaceItemsRequest(new List<string>() { });
-                    var success = await Spotify.Playlists.ReplaceItems(thisPlaylist.Id, request);
-                    if (!success)
-                    {
-                        Log("Error while trying to clear playlist before syncing new tracks");
-                        return errors;
-                    }
-                    thisPlaylistId = thisPlaylist.Id;
-                }
-                else
-                {
-                    var request = new PlaylistCreateRequest(spotifyPlaylistName);
-                    FullPlaylist newPlaylist = await Spotify.Playlists.Create(Profile.Id, request);
-                    thisPlaylistId = newPlaylist.Id;
-                }
-
-
-                List<FullTrack> songsToAdd = new List<FullTrack>();
-                // And get the title and artist of each file, and add it to the Spotify playlist
-                foreach (var song in playlist.Songs)
-                {
-                    string title = song.Title;
-                    string artist = song.Artist;
-                    string album = song.Album;
-
-                    string artistEsc = EscapeChar(artist.ToLower());
-                    string titleEsc = EscapeChar(title.ToLower());
-                    string searchStr = $"artist:{artistEsc} track:{titleEsc}";
-                    var request = new SearchRequest(SearchRequest.Types.Track, searchStr);
-                    SearchResponse search = await Spotify.Search.Item(request);
-
-                    if (search.Tracks == null || search.Tracks.Items == null)
-                    {
-                        Log($"Could not find track on Spotify '{searchStr}' for '{title}' by '{artist}'");
-                        continue;
-                    }
-
-                    if (search.Tracks.Items.Count == 0)
-                    {
-                        Log($"Found 0 results on Spotify for: {searchStr} for '{title}' by '{artist}'");
-                        continue;
-                    }
-
-                    // try to find track matching artist and title
-                    FullTrack trackToAdd = null;
-                    foreach (FullTrack track in search.Tracks.Items)
-                    {
-                        // Titles, artists, and albums could not be exact matches
-                        bool titleMatches = FlexibleStringMatch(track.Name, title);
-                        bool artistMatches = (track.Artists.Exists(a => FlexibleStringMatch(a.Name, artist)));
-                        bool albumMatches = FlexibleStringMatch(track.Album.Name, album);
-                        if (titleMatches && artistMatches && albumMatches)
-                        {
-                            trackToAdd = track;
-                            break;
-                        }
-                    }
-
-                    if (trackToAdd == null)
-                    {
-                        trackToAdd = search.Tracks.Items.FirstOrDefault();
-                        Log($"Didn't find a perfect match for {searchStr} for '{title}' by '{artist}', so using '{trackToAdd.Name}' by '{trackToAdd.Artists.FirstOrDefault().Name}' instead");
-                    }
-
-                    songsToAdd.Add(trackToAdd);
-                }
-
-                List<string> uris = songsToAdd.ConvertAll(x => x.Uri);
-                while (uris.Count > 0)
-                {
-                    List<string> currUris = uris.Take(75).ToList();
-                    if (currUris.Count == 0)
-                    {
-                        break;
-                    }
-
-                    uris.RemoveRange(0, currUris.Count);
-                    var request = new PlaylistAddItemsRequest(currUris);
-                    var resp = await Spotify.Playlists.AddItems(thisPlaylistId, request);
-                    if (resp == null)
-                    {
-                        Log("Error while trying to update playlist with track uris");
-                        return errors;
-                    }
-                }
+                await SaveSpotifyPlaylistPopulatedFromMbPlaylist(settings);
             }
-
-            return errors;
         }
 
         public async Task SyncToMusicBee(List<SimplePlaylist> playlists)
@@ -272,7 +161,9 @@ namespace MusicBeePlugin.Services
 
         public List<IPlaylistSyncError> PopulateErrors { get; private set; } = new List<IPlaylistSyncError>();
         public List<MusicBeeSong> PopulateMusicBeeSongs { get; private set; } = new List<MusicBeeSong>();
-        public SimplePlaylist PopulateSpotifyPlaylist { get; set; } = null;        
+        public List<FullTrack> PopulateSpotifySongs { get; private set; } = new List<FullTrack>();
+        public SimplePlaylist PopulateSpotifyPlaylist { get; set; } = null;
+        public MusicBeePlaylist PopulateMusicBeePlaylist { get; set; } = null;
 
         public async Task PopulateMbPlaylistSongsFromSpotifyPlaylist(bool clearErrors = true)
         {
@@ -350,6 +241,141 @@ namespace MusicBeePlugin.Services
 
                 musicBeeSyncHelper.MbApiInterface.Playlist_CreatePlaylist(playlistRelativeDir, playlistName, mbPlaylistSongFiles);
             });
+
+        public async Task PopulateSpotifyPlaylistSongsFromMbPlaylist(bool clearErrors = true)
+        {
+            if (PopulateMusicBeePlaylist == null)
+            {
+                throw new ArgumentNullException(nameof(PopulateMusicBeePlaylist), "PopulateMusicBeePlaylist cannot be null");
+            }
+
+            if (clearErrors)
+            {
+                PopulateErrors.Clear();
+            }
+            
+            PopulateSpotifySongs.Clear();
+
+            foreach (var song in PopulateMusicBeePlaylist.Songs)
+            {
+                string title = song.Title;
+                string artist = song.Artist;
+                string album = song.Album;
+
+                string artistEsc = EscapeChar(artist.ToLower());
+                string titleEsc = EscapeChar(title.ToLower());
+                string searchStr = $"artist:{artistEsc} track:{titleEsc}";
+                var request = new SearchRequest(SearchRequest.Types.Track, searchStr);
+                SearchResponse search = await Spotify.Search.Item(request);
+
+                if (search.Tracks == null || search.Tracks.Items == null)
+                {
+                    Log($"Could not find track on Spotify '{searchStr}' for '{title}' by '{artist}'");
+                    continue;
+                }
+
+                if (search.Tracks.Items.Count == 0)
+                {
+                    Log($"Found 0 results on Spotify for: {searchStr} for '{title}' by '{artist}'");
+                    continue;
+                }
+
+                // try to find track matching artist and title
+                FullTrack trackToAdd = null;
+                foreach (FullTrack track in search.Tracks.Items)
+                {
+                    // Titles, artists, and albums could not be exact matches
+                    bool titleMatches = FlexibleStringMatch(track.Name, title);
+                    bool artistMatches = (track.Artists.Exists(a => FlexibleStringMatch(a.Name, artist)));
+                    bool albumMatches = FlexibleStringMatch(track.Album.Name, album);
+                    if (titleMatches && artistMatches && albumMatches)
+                    {
+                        trackToAdd = track;
+                        break;
+                    }
+                }
+
+                if (trackToAdd == null)
+                {
+                    trackToAdd = search.Tracks.Items.FirstOrDefault();
+                    Log($"Didn't find a perfect match for {searchStr} for '{title}' by '{artist}', so using '{trackToAdd.Name}' by '{trackToAdd.Artists.FirstOrDefault().Name}' instead");
+                }
+
+                PopulateSpotifySongs.Add(trackToAdd);
+            }
+        }
+
+        public async Task SaveSpotifyPlaylistPopulatedFromMbPlaylist(SyncToSpotifySettings settings)
+        {
+            if (PopulateMusicBeePlaylist == null)
+            {
+                throw new ArgumentNullException(nameof(PopulateMusicBeePlaylist), "PopulateMusicBeePlaylist cannot be null");
+            }
+
+            // Use LINQ to check for a playlist with the same name
+            // If there is one, clear it's contents, otherwise create one
+            // Unless it's been deleted, in which case pretend it doesn't exist.
+            // I'm not sure how to undelete a playlist, or even if you can
+            string spotifyPlaylistName = null;
+            if (settings.IncludeFoldersInPlaylistName)
+            {
+                spotifyPlaylistName = PopulateMusicBeePlaylist.Name;
+            }
+            else
+            {
+                spotifyPlaylistName = PopulateMusicBeePlaylist.Name.Split('\\').Last();
+            }
+
+            if (settings.IncludeZAtStartOfDatePlaylistName)
+            {
+                // if it starts with a 2, it's a date playlist
+                if (spotifyPlaylistName.StartsWith("2"))
+                {
+                    spotifyPlaylistName = $"Z {spotifyPlaylistName}";
+                }
+            }
+
+            // If Spotify playlist with same name already exists, clear it.
+            // Otherwise create one
+            SimplePlaylist thisPlaylist = Playlists.FirstOrDefault(p => p.Name == spotifyPlaylistName);
+            string thisPlaylistId;
+            if (thisPlaylist != null)
+            {
+                var request = new PlaylistReplaceItemsRequest(new List<string>() { });
+                var success = await Spotify.Playlists.ReplaceItems(thisPlaylist.Id, request);
+                if (!success)
+                {
+                    Log("Error while trying to clear playlist before syncing new tracks");
+                    return;
+                }
+                thisPlaylistId = thisPlaylist.Id;
+            }
+            else
+            {
+                var request = new PlaylistCreateRequest(spotifyPlaylistName);
+                FullPlaylist newPlaylist = await Spotify.Playlists.Create(Profile.Id, request);
+                thisPlaylistId = newPlaylist.Id;
+            }
+
+            List<string> uris = PopulateSpotifySongs.ConvertAll(x => x.Uri).ToList();
+            while (uris.Count > 0)
+            {
+                List<string> currUris = uris.Take(75).ToList();
+                if (currUris.Count == 0)
+                {
+                    break;
+                }
+
+                uris.RemoveRange(0, currUris.Count);
+                var request = new PlaylistAddItemsRequest(currUris);
+                var resp = await Spotify.Playlists.AddItems(thisPlaylistId, request);
+                if (resp == null)
+                {
+                    Log("Error while trying to update playlist with track uris");
+                    return;
+                }
+            }
+        }
 
         private string EscapeChar(string input)
         {

--- a/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
+++ b/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Documents;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.StartPanel;
 
 namespace MusicBeePlugin.Services
 {
@@ -16,12 +18,19 @@ namespace MusicBeePlugin.Services
         private SpotifyClient Spotify;
         private Action<string> Log;
         private EmbedIOAuthServer Server;
+        private MusicBeeSyncHelper musicBeeSyncHelper;
 
         public List<SimplePlaylist> Playlists { get; set; } = new List<SimplePlaylist>();
 
-        public SpotifySyncHelper(Action<string> log)
+        public SpotifySyncHelper(Action<string> log, MusicBeeSyncHelper mb)
         {
+            if (mb == null)
+            {
+                throw new ArgumentNullException(nameof(mb), "MusicBeeSyncHelper cannot be null");
+            }
+
             Log = log;
+            musicBeeSyncHelper = mb;
         }
 
         public async Task<bool> LoginAsync()
@@ -208,80 +217,123 @@ namespace MusicBeePlugin.Services
             return errors;
         }
 
-        public async Task<List<IPlaylistSyncError>> SyncToMusicBee(MusicBeeSyncHelper mb, List<SimplePlaylist> playlists)
+        public async Task SyncToMusicBee(List<SimplePlaylist> playlists)
         {
-            List<IPlaylistSyncError> errors = new List<IPlaylistSyncError>();
+            PopulateErrors.Clear();
 
             // Go through each playlist we want to sync in turn
             foreach (SimplePlaylist playlist in playlists)
             {
-                // Create an empty list for this playlist's local songs
-                List<MusicBeeSong> mbPlaylistSongs = new List<MusicBeeSong>();
+                PopulateSpotifyPlaylist = playlist;
+                await PopulateMbPlaylistSongsFromSpotifyPlaylist(false);
 
-                // Get all tracks for playlist
-                var fp = await Spotify.Playlists.Get(playlist.Id);
-                var allTracks = await Spotify.PaginateAll(fp.Tracks);
-                var tracks = new List<FullTrack>();
-                foreach (var t in allTracks)
+                await SaveMbPlaylistPopulatedFromSpotifyPlaylist();
+            }
+
+            // Get the local playlists again
+            musicBeeSyncHelper.RefreshMusicBeePlaylists();
+        }
+
+        private async Task<List<FullTrack>> GetFullTracksFromSpotifyPlaylist(SimplePlaylist playlist)
+        {
+            var tracks = new List<FullTrack>();
+
+            // Get all tracks for playlist
+            var fp = await Spotify.Playlists.Get(playlist.Id);
+            var allTracks = await Spotify.PaginateAll(fp.Tracks);
+            
+            foreach (var t in allTracks)
+            {
+                if (t.Track is FullTrack track)
                 {
-                    if (t.Track is FullTrack track)
-                    {
-                        tracks.Add(track);
-                    }
+                    tracks.Add(track);
                 }
+            }
 
-                foreach (FullTrack track in tracks)
+            return tracks;
+        }
+
+        private MusicBeeSong FindMusicBeeSongFromSpotifyTrack(FullTrack track)
+        {
+            foreach (MusicBeeSong mbSong in musicBeeSyncHelper.Songs)
+            {
+                // Titles, artists, and albums could not be exact matches
+                bool titleMatches = FlexibleStringMatch(track.Name, mbSong.Title);
+                bool artistMatches = (track.Artists.Exists(a => FlexibleStringMatch(a.Name, mbSong.Artist)));
+                bool albumMatches = FlexibleStringMatch(track.Album.Name, mbSong.Album);
+                if (titleMatches && artistMatches && albumMatches)
                 {
-                    MusicBeeSong trackToAdd = null;
-                    foreach (MusicBeeSong mbSong in mb.Songs)
-                    {
-                        // Titles, artists, and albums could not be exact matches
-                        bool titleMatches = FlexibleStringMatch(track.Name, mbSong.Title);
-                        bool artistMatches = (track.Artists.Exists(a => FlexibleStringMatch(a.Name, mbSong.Artist)));
-                        bool albumMatches = FlexibleStringMatch(track.Album.Name, mbSong.Album);
-                        if (titleMatches && artistMatches && albumMatches)
-                        {
-                            trackToAdd = mbSong;
-                            break;
-                        }
-                    }
+                    return mbSong;
+                }
+            }
 
-                    if (trackToAdd != null)
+            return null;
+        }
+
+        public List<IPlaylistSyncError> PopulateErrors { get; private set; } = new List<IPlaylistSyncError>();
+        public List<MusicBeeSong> PopulateMusicBeeSongs { get; private set; } = new List<MusicBeeSong>();
+        public SimplePlaylist PopulateSpotifyPlaylist { get; set; } = null;        
+
+        public async Task PopulateMbPlaylistSongsFromSpotifyPlaylist(bool clearErrors = true)
+        {
+            if (PopulateSpotifyPlaylist == null)
+            {
+                throw new ArgumentNullException(nameof(PopulateSpotifyPlaylist), "PopulateSpotifyPlaylist cannot be null");
+            }
+
+            if (clearErrors)
+            {
+                PopulateErrors.Clear();
+            }
+
+            PopulateMusicBeeSongs.Clear();
+
+            // Get all tracks for playlist
+            var tracks = await GetFullTracksFromSpotifyPlaylist(PopulateSpotifyPlaylist);
+
+            foreach (FullTrack track in tracks)
+            {
+                var trackToAdd = FindMusicBeeSongFromSpotifyTrack(track);
+
+                if (trackToAdd != null)
+                {
+                    PopulateMusicBeeSongs.Add(trackToAdd);
+                }
+                else
+                {
+                    PopulateErrors.Add(new UnableToFindSpotifyTrackError()
                     {
-                        mbPlaylistSongs.Add(trackToAdd);
-                    }
-                    else
-                    {
-                        errors.Add(new UnableToFindSpotifyTrackError()
-                        {
-                            AlbumName = track.Album.Name,
-                            ArtistName = track.Artists.FirstOrDefault().Name,
-                            PlaylistName = playlist.Name,
-                            TrackName = track.Name,
-                            SearchedService = false
-                        });
-                    }
+                        AlbumName = track.Album.Name,
+                        ArtistName = track.Artists.FirstOrDefault().Name,
+                        PlaylistName = PopulateSpotifyPlaylist.Name,
+                        TrackName = track.Name,
+                        SearchedService = false
+                    });
+                }
+            }
+        }
+
+        public async Task SaveMbPlaylistPopulatedFromSpotifyPlaylist() =>
+            await Task.Run(() =>
+            {
+                if (PopulateSpotifyPlaylist == null)
+                {
+                    throw new ArgumentNullException(nameof(PopulateSpotifyPlaylist), "PopulateSpotifyPlaylist cannot be null");
                 }
 
                 //mbAPI expects a string array of song filenames to create a playlist
-                string[] mbPlaylistSongFiles = new string[mbPlaylistSongs.Count];
-                int i = 0;
-                foreach (MusicBeeSong song in mbPlaylistSongs)
-                {
-                    mbPlaylistSongFiles[i] = song.Filename;
-                    i++;
-                }
+                var mbPlaylistSongFiles = PopulateMusicBeeSongs.Select(s => s.Filename).ToArray();
 
                 // Now we need to delete any existing playlist with matching name
-                MusicBeePlaylist localPlaylist = mb.Playlists.FirstOrDefault(p => p.Name == playlist.Name);
+                MusicBeePlaylist localPlaylist = musicBeeSyncHelper.Playlists.FirstOrDefault(p => p.Name == PopulateSpotifyPlaylist.Name);
                 if (localPlaylist != null)
                 {
-                    mb.MbApiInterface.Playlist_DeletePlaylist(localPlaylist.mbName);
+                    musicBeeSyncHelper.MbApiInterface.Playlist_DeletePlaylist(localPlaylist.mbName);
                 }
 
                 // Create the playlist locally
                 string playlistRelativeDir = "";
-                string playlistName = playlist.Name;
+                string playlistName = PopulateSpotifyPlaylist.Name;
 
                 // if it's a date playlist, remove first Z
                 if (playlistName.StartsWith("Z "))
@@ -289,21 +341,15 @@ namespace MusicBeePlugin.Services
                     playlistName = playlistName.Skip(2).ToString();
                 }
 
-                string[] itemsInPath = playlist.Name.Split('\\');
+                string[] itemsInPath = PopulateSpotifyPlaylist.Name.Split('\\');
                 if (itemsInPath.Length > 1)
                 {
                     // Creates a playlist at top level directory
-                    mb.MbApiInterface.Playlist_CreatePlaylist("", playlistName, mbPlaylistSongFiles);
+                    musicBeeSyncHelper.MbApiInterface.Playlist_CreatePlaylist("", playlistName, mbPlaylistSongFiles);
                 }
 
-                mb.MbApiInterface.Playlist_CreatePlaylist(playlistRelativeDir, playlistName, mbPlaylistSongFiles);
-            }
-
-            // Get the local playlists again
-            mb.RefreshMusicBeePlaylists();
-
-            return errors;
-        }
+                musicBeeSyncHelper.MbApiInterface.Playlist_CreatePlaylist(playlistRelativeDir, playlistName, mbPlaylistSongFiles);
+            });
 
         private string EscapeChar(string input)
         {

--- a/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
+++ b/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
@@ -433,5 +433,20 @@ namespace MusicBeePlugin.Services
                 || x.Contains(y)
                 || y.Contains(x);
         }
+
+        public async Task<IEnumerable<FullTrack>> FindSongsInSpotifyDatabase(string artist, string title)
+        {
+            string artistEsc = EscapeChar(artist.ToLower());
+            string titleEsc = EscapeChar(title.ToLower());
+            string searchStr = $"artist:{artistEsc} track:{titleEsc}";
+            var request = new SearchRequest(SearchRequest.Types.Track, searchStr);
+            
+            SearchResponse search = await Spotify.Search.Item(request);
+
+            if (search.Tracks == null || search.Tracks.Items == null)
+                return new List<FullTrack>(0);
+
+            return search.Tracks.Items.ToList();
+        }
     }
 }

--- a/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
+++ b/MusicBeeSyncToService/Services/SpotifySyncHelper.cs
@@ -160,8 +160,7 @@ namespace MusicBeePlugin.Services
         }
 
         public List<IPlaylistSyncError> PopulateErrors { get; private set; } = new List<IPlaylistSyncError>();
-        public List<MusicBeeSong> PopulateMusicBeeSongs { get; private set; } = new List<MusicBeeSong>();
-        public List<FullTrack> PopulateSpotifySongs { get; private set; } = new List<FullTrack>();
+        public List<PopulatedSong> PopulatedSongs { get; private set; } = new List<PopulatedSong>();
         public SimplePlaylist PopulateSpotifyPlaylist { get; set; } = null;
         public MusicBeePlaylist PopulateMusicBeePlaylist { get; set; } = null;
 
@@ -177,27 +176,34 @@ namespace MusicBeePlugin.Services
                 PopulateErrors.Clear();
             }
 
-            PopulateMusicBeeSongs.Clear();
+            PopulatedSongs.Clear();
 
             // Get all tracks for playlist
             var tracks = await GetFullTracksFromSpotifyPlaylist(PopulateSpotifyPlaylist);
 
-            foreach (FullTrack track in tracks)
+            PopulatedSongs.AddRange(tracks.Select(t => new PopulatedSong()
             {
-                var trackToAdd = FindMusicBeeSongFromSpotifyTrack(track);
+                MbSong = null,
+                SpotifySong = t
+            }));
+
+            foreach (var song in PopulatedSongs)
+            {
+                var trackToAdd = FindMusicBeeSongFromSpotifyTrack(song.SpotifySong);
 
                 if (trackToAdd != null)
                 {
-                    PopulateMusicBeeSongs.Add(trackToAdd);
+                    song.MbSong = trackToAdd;
+                    song.Checked = true;
                 }
                 else
                 {
                     PopulateErrors.Add(new UnableToFindSpotifyTrackError()
                     {
-                        AlbumName = track.Album.Name,
-                        ArtistName = track.Artists.FirstOrDefault().Name,
+                        AlbumName = song.SpotifySong.Album.Name,
+                        ArtistName = song.SpotifySong.Artists.FirstOrDefault().Name,
                         PlaylistName = PopulateSpotifyPlaylist.Name,
-                        TrackName = track.Name,
+                        TrackName = song.SpotifySong.Name,
                         SearchedService = false
                     });
                 }
@@ -213,7 +219,10 @@ namespace MusicBeePlugin.Services
                 }
 
                 //mbAPI expects a string array of song filenames to create a playlist
-                var mbPlaylistSongFiles = PopulateMusicBeeSongs.Select(s => s.Filename).ToArray();
+                var mbPlaylistSongFiles = PopulatedSongs
+                    .Where(w => w.Checked && w.MbSong != null)
+                    .Select(s => s.MbSong.Filename)
+                    .ToArray();
 
                 // Now we need to delete any existing playlist with matching name
                 MusicBeePlaylist localPlaylist = musicBeeSyncHelper.Playlists.FirstOrDefault(p => p.Name == PopulateSpotifyPlaylist.Name);
@@ -254,13 +263,19 @@ namespace MusicBeePlugin.Services
                 PopulateErrors.Clear();
             }
             
-            PopulateSpotifySongs.Clear();
+            PopulatedSongs.Clear();
 
-            foreach (var song in PopulateMusicBeePlaylist.Songs)
+            PopulatedSongs.AddRange(PopulateMusicBeePlaylist.Songs.Select(s => new PopulatedSong()
             {
-                string title = song.Title;
-                string artist = song.Artist;
-                string album = song.Album;
+                MbSong = s,
+                SpotifySong = null
+            }));
+
+            foreach (var song in PopulatedSongs)
+            {
+                string title = song.MbSong.Title;
+                string artist = song.MbSong.Artist;
+                string album = song.MbSong.Album;
 
                 string artistEsc = EscapeChar(artist.ToLower());
                 string titleEsc = EscapeChar(title.ToLower());
@@ -301,7 +316,8 @@ namespace MusicBeePlugin.Services
                     Log($"Didn't find a perfect match for {searchStr} for '{title}' by '{artist}', so using '{trackToAdd.Name}' by '{trackToAdd.Artists.FirstOrDefault().Name}' instead");
                 }
 
-                PopulateSpotifySongs.Add(trackToAdd);
+                song.SpotifySong = trackToAdd;
+                song.Checked = true;
             }
         }
 
@@ -357,7 +373,11 @@ namespace MusicBeePlugin.Services
                 thisPlaylistId = newPlaylist.Id;
             }
 
-            List<string> uris = PopulateSpotifySongs.ConvertAll(x => x.Uri).ToList();
+            var uris = PopulatedSongs
+                .Where(w => w.Checked && w.SpotifySong != null)
+                .Select(s => s.SpotifySong.Uri)
+                .ToList();
+
             while (uris.Count > 0)
             {
                 List<string> currUris = uris.Take(75).ToList();

--- a/MusicBeeSyncToService/WPF/FullTrackStringConverter.cs
+++ b/MusicBeeSyncToService/WPF/FullTrackStringConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace MusicBeePlugin.WPF
+{
+    public class FullTrackStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var FullTrack = value as SpotifyAPI.Web.FullTrack;
+
+            if (FullTrack == null)
+                return "";
+
+            return String.Join("; ", FullTrack.Artists.Select(a => a.Name)) + " - " + FullTrack.Name;         
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml
@@ -53,7 +53,7 @@
         <Label Content="Logging" Margin="10,4,0,2" Padding="0"/>
         <TextBox x:Name="OutputTextBox" Grid.Row="1" Margin="10,0,10,10" TextWrapping="Wrap" IsReadOnly="True"/>
 
-        <Grid x:Name="FirstSectionPanel" Visibility="Hidden" Grid.Row="2">
+        <Grid x:Name="FirstSectionPanel" Visibility="Visible" Grid.Row="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -100,13 +100,18 @@
             </Grid>
         </Grid>
 
-        <Grid x:Name="SecondSectionPanelToMB" Visibility="Visible" Grid.Row="2" Margin="10,0,10,10">
+        <Grid x:Name="SecondSectionPanelToMB" Visibility="Hidden" Grid.Row="2" Margin="10,0,10,10">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <Grid HorizontalAlignment="Stretch" Margin="7,0,24,0">
+            <StackPanel Grid.Row="0" Orientation="Horizontal">
+                <Label Padding="4,2" VerticalAlignment="Center" Content="Search song: " />
+                <TextBox x:Name="LibrarySearchBox" MinWidth="200" VerticalAlignment="Center" Padding="2" TextChanged="LibrarySearchBox_TextChanged" PreviewKeyUp="LibrarySearchBox_PreviewKeyUp"/>
+            </StackPanel>
+            <Grid Grid.Row="1" HorizontalAlignment="Stretch" Margin="7,0,24,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="20"/>
                     <ColumnDefinition Width="1*"/>
@@ -115,7 +120,7 @@
                 <Label Grid.Column="1" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="MusicBee Library"/>
                 <Label Grid.Column="2" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="Spotify Library"/>
             </Grid>
-            <ListBox x:Name="MBSongConferenceListBox" Grid.Row="1" HorizontalContentAlignment="Stretch" 
+            <ListBox x:Name="MBSongConferenceListBox" Grid.Row="2" HorizontalContentAlignment="Stretch" 
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
                      ScrollViewer.VerticalScrollBarVisibility="Visible"
                      ItemsSource="{x:Static model:PopulatedSongsForDesign.Songs}">
@@ -134,10 +139,27 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-            <StackPanel Grid.Row="2" Margin="0,6,0,0" HorizontalAlignment="Center" Orientation="Horizontal">
+            <StackPanel Grid.Row="3" Margin="0,6,0,0" HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button Padding="16, 4" Content="Back to playlist selection" Click="ButtonBackToPlaylistSelect_Click" />
                 <Button Padding="16, 4" Margin="10,0,0,0" Content="Continue to sync" Click="ButtonContinueToSinc_Click" />
             </StackPanel>
+            <ListBox x:Name="FindResultsFromLibrary" Visibility="Hidden" Grid.Row="0" Grid.RowSpan="4" 
+                     HorizontalAlignment="Left" 
+                     VerticalAlignment="Top" 
+                     Margin="80,28,0,0"
+                     PreviewKeyDown="FindResultsFromLibrary_PreviewKeyDown">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Label Content="{Binding Song}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Grid>
+
+        <Grid x:Name="SecondSectionPanelToSpotify" Visibility="Hidden" Grid.Row="2" Margin="10,0,10,10">
+            <Label Content="Not implemented yet" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+            <Button Padding="16, 4" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0,50,0,0"
+                    Content="Back to playlist selection" Click="ButtonBackToPlaylistSelect_Click" />
         </Grid>
     </Grid>
 </Window>

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:MusicBeePlugin.WPF"
         xmlns:model="clr-namespace:MusicBeePlugin.Models"
         mc:Ignorable="d"
         Title="Sync with Spotify" 
@@ -43,6 +44,7 @@
             <Setter Property="Background" Value="{DynamicResource backCtrlColor}" />
             <Setter Property="Foreground" Value="{DynamicResource foreCtrlColor}" />
         </Style>
+        <local:FullTrackStringConverter x:Key="FullTrackStringConverter" />
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -53,7 +55,7 @@
         <Label Content="Logging" Margin="10,4,0,2" Padding="0"/>
         <TextBox x:Name="OutputTextBox" Grid.Row="1" Margin="10,0,10,10" TextWrapping="Wrap" IsReadOnly="True"/>
 
-        <Grid x:Name="FirstSectionPanel" Visibility="Visible" Grid.Row="2">
+        <Grid x:Name="FirstSectionPanel" Visibility="Hidden" Grid.Row="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -100,17 +102,28 @@
             </Grid>
         </Grid>
 
-        <Grid x:Name="SecondSectionPanelToMB" Visibility="Hidden" Grid.Row="2" Margin="10,0,10,10">
+        <Grid x:Name="SecondSectionPanel" Visibility="Visible" Grid.Row="2" Margin="10,0,10,10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <StackPanel Grid.Row="0" Orientation="Horizontal">
-                <Label Padding="4,2" VerticalAlignment="Center" Content="Search song: " />
-                <TextBox x:Name="LibrarySearchBox" MinWidth="200" VerticalAlignment="Center" Padding="2" TextChanged="LibrarySearchBox_TextChanged" PreviewKeyUp="LibrarySearchBox_PreviewKeyUp"/>
-            </StackPanel>
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label x:Name="ServiceTypeLabel" FontWeight="Bold" />
+                <Label Grid.Column="1" Padding="4,2" VerticalAlignment="Center" Content="Search song: " />
+                <TextBox x:Name="SongSearchBox" Grid.Column="2" MinWidth="200" VerticalAlignment="Center" Padding="2"
+                         TextChanged="SongSearchBox_TextChanged" 
+                         PreviewKeyUp="SongSearchBox_PreviewKeyUp"/>
+                <Label x:Name="SpotifySearchHint" Grid.ColumnSpan="3" HorizontalAlignment="Right" VerticalAlignment="Top" 
+                       FontSize="7pt" Margin="0,-12,0,0" Padding="0" Visibility="Hidden"
+                       Content="to search enter &lt;artist&gt; - &lt;title&gt; format, can be partial" />
+            </Grid>
             <Grid Grid.Row="1" HorizontalAlignment="Stretch" Margin="7,0,24,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="20"/>
@@ -120,7 +133,7 @@
                 <Label Grid.Column="1" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="MusicBee Library"/>
                 <Label Grid.Column="2" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="Spotify Library"/>
             </Grid>
-            <ListBox x:Name="MBSongConferenceListBox" Grid.Row="2" HorizontalContentAlignment="Stretch" 
+            <ListBox x:Name="SongConferenceListBox" Grid.Row="2" HorizontalContentAlignment="Stretch" 
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
                      ScrollViewer.VerticalScrollBarVisibility="Visible"
                      ItemsSource="{x:Static model:PopulatedSongsForDesign.Songs}">
@@ -140,13 +153,14 @@
                 </ListBox.ItemTemplate>
             </ListBox>
             <StackPanel Grid.Row="3" Margin="0,6,0,0" HorizontalAlignment="Center" Orientation="Horizontal">
-                <Button Padding="16, 4" Content="Back to playlist selection" Click="ButtonBackToPlaylistSelect_Click" />
-                <Button Padding="16, 4" Margin="10,0,0,0" Content="Continue to sync" Click="ButtonContinueToSinc_Click" />
+                <Button x:Name="BtnBackSelection" Padding="16, 4" Content="Back to playlist selection" Click="ButtonBackToPlaylistSelect_Click" />
+                <Button x:Name="BtnContinueSync" Padding="16, 4" Margin="10,0,0,0" Content="Continue to sync" Click="ButtonContinueToSinc_Click" />
             </StackPanel>
             <ListBox x:Name="FindResultsFromLibrary" Visibility="Hidden" Grid.Row="0" Grid.RowSpan="4" 
-                     HorizontalAlignment="Left" 
+                     HorizontalAlignment="Right" 
                      VerticalAlignment="Top" 
-                     Margin="80,28,0,0"
+                     Margin="0,24,0,0"
+                     MouseDoubleClick="FindResultsFromLibrary_MouseDoubleClick"
                      PreviewKeyDown="FindResultsFromLibrary_PreviewKeyDown">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
@@ -154,12 +168,19 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
+            <ListBox x:Name="FindResultsFromSpotify" Visibility="Hidden" Grid.Row="0" Grid.RowSpan="4" 
+                     HorizontalAlignment="Right" 
+                     VerticalAlignment="Top" 
+                     Margin="0,24,0,0"
+                     MouseDoubleClick="FindResultsFromSpotify_MouseDoubleClick"
+                     PreviewKeyDown="FindResultsFromSpotify_PreviewKeyDown">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Label Content="{Binding Converter={StaticResource FullTrackStringConverter}}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
         </Grid>
 
-        <Grid x:Name="SecondSectionPanelToSpotify" Visibility="Hidden" Grid.Row="2" Margin="10,0,10,10">
-            <Label Content="Not implemented yet" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-            <Button Padding="16, 4" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0,50,0,0"
-                    Content="Back to playlist selection" Click="ButtonBackToPlaylistSelect_Click" />
-        </Grid>
     </Grid>
 </Window>

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:model="clr-namespace:MusicBeePlugin.Models"
         mc:Ignorable="d"
         Title="Sync with Spotify" 
         MinWidth="600" 
@@ -52,7 +53,7 @@
         <Label Content="Logging" Margin="10,4,0,2" Padding="0"/>
         <TextBox x:Name="OutputTextBox" Grid.Row="1" Margin="10,0,10,10" TextWrapping="Wrap" IsReadOnly="True"/>
 
-        <Grid x:Name="FirstSectionPanel" Grid.Row="2">
+        <Grid x:Name="FirstSectionPanel" Visibility="Hidden" Grid.Row="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -97,6 +98,46 @@
                     </ListBox.ItemTemplate>
                 </ListBox>
             </Grid>
+        </Grid>
+
+        <Grid x:Name="SecondSectionPanelToMB" Visibility="Visible" Grid.Row="2" Margin="10,0,10,10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid HorizontalAlignment="Stretch" Margin="7,0,24,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="20"/>
+                    <ColumnDefinition Width="1*"/>
+                    <ColumnDefinition Width="1*"/>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Column="1" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="MusicBee Library"/>
+                <Label Grid.Column="2" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="Spotify Library"/>
+            </Grid>
+            <ListBox x:Name="MBSongConferenceListBox" Grid.Row="1" HorizontalContentAlignment="Stretch" 
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                     ScrollViewer.VerticalScrollBarVisibility="Visible"
+                     ItemsSource="{x:Static model:PopulatedSongsForDesign.Songs}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid HorizontalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="20"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                            </Grid.ColumnDefinitions>
+                            <CheckBox IsChecked="{Binding Checked}"/>
+                            <Label Grid.Column="1" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="{Binding MbSongDisplayName}"/>
+                            <Label Grid.Column="2" Padding="0" VerticalAlignment="Center" Margin="0,0,5,0" Content="{Binding SpotifySongDisplayName}"/>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <StackPanel Grid.Row="2" Margin="0,6,0,0" HorizontalAlignment="Center" Orientation="Horizontal">
+                <Button Padding="16, 4" Content="Back to playlist selection" Click="ButtonBackToPlaylistSelect_Click" />
+                <Button Padding="16, 4" Margin="10,0,0,0" Content="Continue to sync" Click="ButtonContinueToSinc_Click" />
+            </StackPanel>
         </Grid>
     </Grid>
 </Window>

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml
@@ -4,36 +4,99 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="MainWindow" Height="700" Width="680" Background="Gray">
+        Title="Sync with Spotify" 
+        MinWidth="600" 
+        MinHeight="500" 
+        Height="700" 
+        Width="680" 
+        ResizeMode="CanResize"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="ToolWindow"
+        Background="{DynamicResource backColor}">
+    <Window.Resources>
+        <SolidColorBrush x:Key="backColor" Color="Gray" />
+        <SolidColorBrush x:Key="foreColor" Color="Black" />
+        <SolidColorBrush x:Key="backCtrlColor" Color="Gray" />
+        <SolidColorBrush x:Key="foreCtrlColor" Color="DarkBlue" />
+        <SolidColorBrush x:Key="backCtrlModColor" Color="Gray" />
+        <SolidColorBrush x:Key="foreCtrlModColor" Color="DarkBlue" />
+        <Style TargetType="Label">
+            <Setter Property="Foreground" Value="{DynamicResource foreColor}" />
+        </Style>
+        <Style TargetType="CheckBox">
+            <Setter Property="Foreground" Value="{DynamicResource foreColor}" />
+        </Style>
+        <Style TargetType="RadioButton">
+            <Setter Property="Foreground" Value="{DynamicResource foreColor}" />
+        </Style>
+        <Style TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource backCtrlColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource foreCtrlColor}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource foreCtrlColor}" />
+        </Style>
+        <Style TargetType="TextBox">
+            <Setter Property="Background" Value="{DynamicResource backCtrlColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource foreCtrlColor}" />
+        </Style>
+        <Style TargetType="ListBox">
+            <Setter Property="Background" Value="{DynamicResource backCtrlColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource foreCtrlColor}" />
+        </Style>
+    </Window.Resources>
     <Grid>
-        <TextBox x:Name="OutputTextBox" HorizontalAlignment="Left" Height="160" Margin="10,10,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="655" IsReadOnly="True"/>
-        <CheckBox x:Name="IncludeFoldersCheckBox" Content="Include Folders in Playlist Name" IsChecked="False" HorizontalAlignment="Left" Margin="10,648,0,0" VerticalAlignment="Top"/>
-        <CheckBox x:Name="IncludeZCheckBox" Content="Include Z at Start of Date Playlists" IsChecked="False"  HorizontalAlignment="Left" Margin="203,648,0,0" VerticalAlignment="Top"/>
-        <ListBox x:Name="MusicBeeListBox" HorizontalAlignment="Left" Height="468" Margin="10,175,0,0" VerticalAlignment="Top" Width="300">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <CheckBox IsChecked="{Binding IsChecked}" Content="{Binding Path=Name}"/>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-        <TabControl HorizontalAlignment="Left" Height="468" Margin="355,175,10,0" VerticalAlignment="Top" Width="320">
-            <TabItem Header="Spotify">
-                <Grid>
-                    <Button x:Name="SpotifyLoginButton" Click="SpotifyLoginButton_ClickAsync" Content="Login" HorizontalAlignment="Left" VerticalAlignment="Top" Width="75" Margin="10,9,0,0"/>
-                    <Button x:Name="SpotifySyncButton" Click="SpotifySyncButton_Click" Content="Synchronize Selected" IsEnabled="False" HorizontalAlignment="Left" Margin="172,10,0,0" VerticalAlignment="Top" Width="118" Height="20"/>
-                    <CheckBox x:Name="SpotifySelectAllButton" Content="Select All" Checked="SpotifySelectAllButton_Checked" Unchecked="SpotifySelectAllButton_Unchecked" HorizontalAlignment="Left" Margin="98,12,0,0" VerticalAlignment="Top" IsEnabled="False"/>
-                    <ListBox x:Name="SpotifyPlaylistListBox"  HorizontalAlignment="Left" Height="405" Margin="10,35,0,0" VerticalAlignment="Top" Width="280">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <CheckBox IsChecked="{Binding IsChecked}" Content="{Binding Path=Name}"/>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </Grid>
-            </TabItem>
-        </TabControl>
-        <RadioButton x:Name="SyncToServiceRadioButton" Content="->" HorizontalAlignment="Left" Margin="315,368,0,0" VerticalAlignment="Top" IsChecked="True"/>
-        <RadioButton x:Name="SyncToMusicBeeRadioButton" Content="&lt;- " HorizontalAlignment="Left" Margin="315,388,0,0" VerticalAlignment="Top" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="160"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Label Content="Logging" Margin="10,4,0,2" Padding="0"/>
+        <TextBox x:Name="OutputTextBox" Grid.Row="1" Margin="10,0,10,10" TextWrapping="Wrap" IsReadOnly="True"/>
 
+        <Grid x:Name="FirstSectionPanel" Grid.Row="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                <CheckBox x:Name="IncludeFoldersCheckBox" Margin="10,0" Content="Include Folders in Playlist Name" IsChecked="False" />
+                <CheckBox x:Name="IncludeZCheckBox" Margin="10,0" Content="Include Z at Start of Date Playlists" IsChecked="False" />
+            </StackPanel>
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0">
+                <RadioButton x:Name="SyncToServiceRadioButton" Margin="10,0" Content="MB to Spotify" IsChecked="True"/>
+                <RadioButton x:Name="SyncToMusicBeeRadioButton" Margin="10,0" Content="Spotify to MB" />
+            </StackPanel>
+
+            <Grid Grid.Row="2" Margin="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1*"/>
+                    <ColumnDefinition Width="1*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <ListBox x:Name="MusicBeeListBox" Grid.Column="0" Grid.Row="0" Grid.RowSpan="2" Margin="0,0,5,0">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Foreground="{DynamicResource foreCtrlColor}" IsChecked="{Binding IsChecked}" Content="{Binding Path=Name}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <StackPanel Grid.Column="1" Grid.Row="0" Margin="0,0,0,4" Orientation="Horizontal">
+                    <Button x:Name="SpotifyLoginButton" Padding="16, 2" Margin="0,0,6,0" Click="SpotifyLoginButton_ClickAsync" Content="Login"/>
+                    <Button x:Name="SpotifySyncButton" Padding="16, 2" Margin="0,0,6,0" Click="SpotifySyncButton_Click" Content="Synchronize Selected" IsEnabled="False"/>
+                    <CheckBox x:Name="SpotifySelectAllButton" VerticalAlignment="Center" Content="Select All" Checked="SpotifySelectAllButton_Checked" Unchecked="SpotifySelectAllButton_Unchecked" IsEnabled="False"/>
+                </StackPanel>
+                <ListBox x:Name="SpotifyPlaylistListBox" Grid.Column="1" Grid.Row="1">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Foreground="{DynamicResource foreCtrlColor}" IsChecked="{Binding IsChecked}" Content="{Binding Path=Name}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Grid>
     </Grid>
 </Window>

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
@@ -49,7 +49,7 @@ namespace MBSyncToServiceUI
             RefreshMusicBeePlaylists();
 
             Action<string> log = (s) => Dispatcher.Invoke(() => { Log(s); });
-            Spotify = new SpotifySyncHelper(log);
+            Spotify = new SpotifySyncHelper(log, MusicBee);
         }
 
         private static Color IntToColor(int color)
@@ -143,7 +143,8 @@ namespace MBSyncToServiceUI
                 else
                 {
                     List<SimplePlaylist> spotifyPlaylistsToSync = GetSpotifyPlaylistsToSync();
-                    errors = await Spotify.SyncToMusicBee(MusicBee, spotifyPlaylistsToSync);
+                    await Spotify.SyncToMusicBee(spotifyPlaylistsToSync);
+                    errors = Spotify.PopulateErrors;
                     RefreshMusicBeePlaylists();
                 }
 

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
@@ -9,6 +9,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media;
+using static MusicBeePlugin.Plugin;
 
 namespace MBSyncToServiceUI
 {
@@ -30,6 +32,16 @@ namespace MBSyncToServiceUI
         {
             InitializeComponent();
 
+            int backColor = apiInterface.Setting_GetSkinElementColour(SkinElement.SkinInputPanel, ElementState.ElementStateDefault, ElementComponent.ComponentBackground);
+            int foreColor = apiInterface.Setting_GetSkinElementColour(SkinElement.SkinInputPanel, ElementState.ElementStateDefault, ElementComponent.ComponentForeground);
+            int backCtrlColor = apiInterface.Setting_GetSkinElementColour(SkinElement.SkinInputControl , ElementState.ElementStateDefault, ElementComponent.ComponentBackground);
+            int foreCtrlColor = apiInterface.Setting_GetSkinElementColour(SkinElement.SkinInputControl, ElementState.ElementStateDefault, ElementComponent.ComponentForeground);
+
+            Resources["backColor"] = new SolidColorBrush(IntToColor(backColor));
+            Resources["foreColor"] = new SolidColorBrush(IntToColor(foreColor));
+            Resources["backCtrlColor"] = new SolidColorBrush(IntToColor(backCtrlColor));
+            Resources["foreCtrlColor"] = new SolidColorBrush(IntToColor(foreCtrlColor));
+
             MusicBeePlaylists = new ObservableCollection<CheckedListItem<MusicBeePlaylist>>();
             SpotifyPlaylists = new ObservableCollection<CheckedListItem<SpotifyPlaylist>>();
 
@@ -38,6 +50,12 @@ namespace MBSyncToServiceUI
 
             Action<string> log = (s) => Dispatcher.Invoke(() => { Log(s); });
             Spotify = new SpotifySyncHelper(log);
+        }
+
+        private static Color IntToColor(int color)
+        {
+            var drawingColor = System.Drawing.Color.FromArgb(color);
+            return Color.FromArgb(drawingColor.A, drawingColor.R, drawingColor.G, drawingColor.B);
         }
 
 

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
@@ -50,6 +51,8 @@ namespace MBSyncToServiceUI
 
             Action<string> log = (s) => Dispatcher.Invoke(() => { Log(s); });
             Spotify = new SpotifySyncHelper(log, MusicBee);
+
+            ClearPanelsVisibility();
         }
 
         private static Color IntToColor(int color)
@@ -117,14 +120,121 @@ namespace MBSyncToServiceUI
             }
         }
 
+        private void ButtonBackToPlaylistSelect_Click(object sender, RoutedEventArgs e)
+        {
+            ClearPanelsVisibility();
+        }
+        private void ButtonContinueToSinc_Click(object sender, RoutedEventArgs e)
+        {
+            _ = SpotifyToMbSavePopulatedList();
+        }
+
+        private void ClearPanelsVisibility()
+        {
+            FirstSectionPanel.Visibility = Visibility.Visible;
+            SecondSectionPanelToMB.Visibility = Visibility.Hidden;
+        }
+
         private async void SpotifySyncButton_Click(object sender, RoutedEventArgs e)
         {
-            List<IPlaylistSyncError> errors = new List<IPlaylistSyncError>();
             string direction = (SyncToService ? "to" : "from");
             Log($"Starting sync {direction} Spotify...");
             SpotifySelectAllButton.IsEnabled = false;
             SpotifySyncButton.IsEnabled = false;
 
+            int toSyncCount = (SyncToService ? GetMusicBeePlaylistsToSync().Count : GetSpotifyPlaylistsToSync().Count);
+
+            if (toSyncCount == 1)
+            {
+                FirstSectionPanel.Visibility = Visibility.Hidden;
+                if (SyncToService)
+                {
+
+                }
+                else
+                {
+                    SecondSectionPanelToMB.Visibility = Visibility.Visible;
+                    await SpotifyToMbPopulateSongsOfSelectedPlaylist();
+                    Log($"Finished to populate the list.");
+                }
+            }
+            else if(toSyncCount > 1)
+            {
+                if (MessageBox.Show($"Are you really sure that you want to sync {toSyncCount} playlists automatic?", Title, MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
+                {
+                    await SpotifySyncMultiplePlaylists();
+                    Log($"Finished sync {direction} Spotify.");
+                }
+            }
+            else
+            {
+                Log("Nothing done, select one playlist or more.");
+            }
+
+            SpotifySelectAllButton.IsEnabled = true;
+            SpotifySyncButton.IsEnabled = true;            
+        }
+
+        private async Task SpotifyToMbPopulateSongsOfSelectedPlaylist()
+        {
+            MBSongConferenceListBox.ItemsSource = null;
+            try
+            {
+                var spotifyPlaylistsToSync = GetSpotifyPlaylistsToSync().First();
+
+                Spotify.PopulateSpotifyPlaylist = spotifyPlaylistsToSync;
+                await Spotify.PopulateMbPlaylistSongsFromSpotifyPlaylist();
+
+                MBSongConferenceListBox.ItemsSource = Spotify.PopulatedSongs;
+
+                if (Spotify.PopulateErrors.Count > 0)
+                {
+                    var errors = Spotify
+                        .PopulateErrors
+                        .Select(s => s.GetMessage())
+                        .Aggregate(new StringBuilder(), (sb, s) =>
+                        {
+                            sb.AppendLine(s);
+                            return sb;
+                        });
+
+                    Log(errors.ToString());
+                    Log("See errors above");
+                }
+                else
+                {
+                    Log($"Successfully populated songs from Spotify");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log(ex.Message);
+            }
+        }
+
+        private async Task SpotifyToMbSavePopulatedList()
+        {
+            try
+            {
+                if (Spotify.PopulatedSongs.Where(w => w.Checked).Count() == 0)
+                {
+                    MessageBox.Show("No songs selected to save", Title, MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                await Spotify.SaveMbPlaylistPopulatedFromSpotifyPlaylist();
+                Log($"Successfully saved playlist from Spotify");
+            }
+            catch (Exception ex)
+            {
+                Log(ex.Message);
+            }
+        }
+
+        private async Task SpotifySyncMultiplePlaylists()
+        {
+            var direction = (SyncToService ? "to" : "from");
+            var errors = new List<IPlaylistSyncError>();
             try
             {
                 if (SyncToService)
@@ -166,12 +276,8 @@ namespace MBSyncToServiceUI
             {
                 Log(ex.Message);
             }
-
-
-            SpotifySelectAllButton.IsEnabled = true;
-            SpotifySyncButton.IsEnabled = true;
-            Log($"Finished sync {direction} Spotify.");
         }
+
         private List<SimplePlaylist> GetSpotifyPlaylistsToSync()
         {
             List<SimplePlaylist> results = new List<SimplePlaylist>();

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
@@ -137,7 +137,8 @@ namespace MBSyncToServiceUI
                         IncludeZAtStartOfDatePlaylistName = IncludeZ,
                     };
 
-                    errors = await Spotify.SyncToSpotify(MusicBee, mbPlaylistsToSync, settings);
+                    await Spotify.SyncToSpotify(mbPlaylistsToSync, settings);
+                    errors = Spotify.PopulateErrors;
                     await RefreshSpotifyPlaylists();
                 }
                 else

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
@@ -10,7 +10,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Forms.Integration;
 using System.Windows.Media;
+using System.Windows.Threading;
 using static MusicBeePlugin.Plugin;
 
 namespace MBSyncToServiceUI
@@ -29,9 +33,16 @@ namespace MBSyncToServiceUI
         public ObservableCollection<CheckedListItem<MusicBeePlaylist>> MusicBeePlaylists { get; set; }
         public ObservableCollection<CheckedListItem<SpotifyPlaylist>> SpotifyPlaylists { get; set; }
 
+        public ObservableCollection<MusicBeeSongSearch> LibrarySearchResults { get; set; }
+        public MusicBeeSongSearch LibrarySearchResultsSelected { get; set; }
+
+        public PopulatedSong PopulatedSongFromSpotifySelected { get; set; }
+
         public MainWindow(Plugin.MusicBeeApiInterface apiInterface)
         {
             InitializeComponent();
+
+            ElementHost.EnableModelessKeyboardInterop(this);
 
             int backColor = apiInterface.Setting_GetSkinElementColour(SkinElement.SkinInputPanel, ElementState.ElementStateDefault, ElementComponent.ComponentBackground);
             int foreColor = apiInterface.Setting_GetSkinElementColour(SkinElement.SkinInputPanel, ElementState.ElementStateDefault, ElementComponent.ComponentForeground);
@@ -45,6 +56,10 @@ namespace MBSyncToServiceUI
 
             MusicBeePlaylists = new ObservableCollection<CheckedListItem<MusicBeePlaylist>>();
             SpotifyPlaylists = new ObservableCollection<CheckedListItem<SpotifyPlaylist>>();
+            LibrarySearchResults = new ObservableCollection<MusicBeeSongSearch>();
+
+            FindResultsFromLibrary.ItemsSource = LibrarySearchResults;
+            FindResultsFromLibrary.SetBinding(ListBox.SelectedItemProperty, new Binding("LibrarySearchResultsSelected") { Source = this, Mode = BindingMode.TwoWay });
 
             MusicBee = new MusicBeeSyncHelper(apiInterface);
             RefreshMusicBeePlaylists();
@@ -133,6 +148,9 @@ namespace MBSyncToServiceUI
         {
             FirstSectionPanel.Visibility = Visibility.Visible;
             SecondSectionPanelToMB.Visibility = Visibility.Hidden;
+            SecondSectionPanelToSpotify.Visibility = Visibility.Hidden;
+
+            MBSongConferenceListBox.ItemsSource = null;
         }
 
         private async void SpotifySyncButton_Click(object sender, RoutedEventArgs e)
@@ -149,7 +167,7 @@ namespace MBSyncToServiceUI
                 FirstSectionPanel.Visibility = Visibility.Hidden;
                 if (SyncToService)
                 {
-
+                    SecondSectionPanelToSpotify.Visibility = Visibility.Visible;
                 }
                 else
                 {
@@ -186,6 +204,7 @@ namespace MBSyncToServiceUI
                 await Spotify.PopulateMbPlaylistSongsFromSpotifyPlaylist();
 
                 MBSongConferenceListBox.ItemsSource = Spotify.PopulatedSongs;
+                MBSongConferenceListBox.SetBinding(ListBox.SelectedItemProperty, new Binding("PopulatedSongFromSpotifySelected") { Source = this, Mode = BindingMode.TwoWay });
 
                 if (Spotify.PopulateErrors.Count > 0)
                 {
@@ -328,7 +347,128 @@ namespace MBSyncToServiceUI
                 item.IsChecked = isChecked;
             }
         }
-        #endregion
+        #endregion      
 
+
+        private void ChangePopuplatedSongFromSpotifyLibraryRelated(MusicBeeSongSearch changeTo)
+        {
+            if (PopulatedSongFromSpotifySelected != null)
+            {
+                PopulatedSongFromSpotifySelected.MbSong = changeTo.Song;
+                PopulatedSongFromSpotifySelected.Checked = true;
+
+                MBSongConferenceListBox.Items.Refresh();
+            }    
+        }
+
+        private void SearchOnLibrary(string text)
+        {
+            LibrarySearchResults.Clear();
+
+            try
+            {
+                text = text.Trim();
+                if (text.Length <= 2)
+                    return;
+
+                var words  = text
+                    .Split(' ')
+                    .Select(s=> s.ToLower())
+                    .ToArray();
+
+                var results = MusicBee.FindSongsByWords(words);
+
+                foreach (var result in results)
+                    LibrarySearchResults.Add(result);
+            }
+            catch 
+            {
+                Log("Something goes wrong at search.");
+            }
+            finally
+            {
+                FindResultsFromLibrary.Visibility = LibrarySearchResults.Any() ? Visibility.Visible : Visibility.Hidden;
+            }
+        }
+        private void ClearFindResultsFromLibrary()
+        {
+            FindResultsFromLibrary.Visibility = Visibility.Hidden;
+            LibrarySearchResultsSelected = null;
+            LibrarySearchResults.Clear();
+        }
+
+        private DispatcherTimer searchLibraryDelayTimer = null;
+
+        private void LibrarySearchBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            if (searchLibraryDelayTimer == null)
+            {
+                searchLibraryDelayTimer = new DispatcherTimer();
+                searchLibraryDelayTimer.Interval = TimeSpan.FromMilliseconds(300);
+                searchLibraryDelayTimer.Tick += new EventHandler((s, ee) =>
+                {
+                    searchLibraryDelayTimer.Stop();
+                    SearchOnLibrary(LibrarySearchBox.Text);
+                });
+            }
+
+            searchLibraryDelayTimer.Stop();
+            searchLibraryDelayTimer.Start();
+        }
+
+        private void LibrarySearchBox_PreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                e.Handled = true;
+
+                if (LibrarySearchResults.Any())
+                {
+                    var changeTo = LibrarySearchResults.First();
+                    ChangePopuplatedSongFromSpotifyLibraryRelated(changeTo);
+                }
+
+                ClearFindResultsFromLibrary();
+            }
+            else if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                e.Handled = true;
+                ClearFindResultsFromLibrary();
+                LibrarySearchBox.Text = "";
+            }
+            else if (e.Key == System.Windows.Input.Key.Down)
+            {
+                e.Handled = true;
+                if (FindResultsFromLibrary.IsVisible)
+                {
+                    if (LibrarySearchResults.Count > 1)
+                    {
+                        FindResultsFromLibrary.SelectedIndex = 1;
+                        FindResultsFromLibrary.UpdateLayout();
+                        FindResultsFromLibrary.Focus();
+                    }
+                    else
+                        FindResultsFromLibrary.Focus();
+                }
+            }
+        }
+
+        private void FindResultsFromLibrary_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                e.Handled = true;
+                ClearFindResultsFromLibrary();
+            }
+            else if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                e.Handled = true;
+                
+                if (LibrarySearchResultsSelected != null)
+                    ChangePopuplatedSongFromSpotifyLibraryRelated(LibrarySearchResultsSelected);
+
+                ClearFindResultsFromLibrary();
+            }
+        }
     }
 }

--- a/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
+++ b/MusicBeeSyncToService/WPF/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -16,6 +17,8 @@ using System.Windows.Forms.Integration;
 using System.Windows.Media;
 using System.Windows.Threading;
 using static MusicBeePlugin.Plugin;
+using static System.Net.Mime.MediaTypeNames;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.StartPanel;
 
 namespace MBSyncToServiceUI
 {
@@ -36,7 +39,10 @@ namespace MBSyncToServiceUI
         public ObservableCollection<MusicBeeSongSearch> LibrarySearchResults { get; set; }
         public MusicBeeSongSearch LibrarySearchResultsSelected { get; set; }
 
-        public PopulatedSong PopulatedSongFromSpotifySelected { get; set; }
+        public ObservableCollection<FullTrack> SpotifySongSearchResults { get; set; }
+        public FullTrack SpotifySongSearchResultsSelected { get; set; }
+
+        public PopulatedSong PopulatedSongSelected { get; set; }
 
         public MainWindow(Plugin.MusicBeeApiInterface apiInterface)
         {
@@ -57,9 +63,7 @@ namespace MBSyncToServiceUI
             MusicBeePlaylists = new ObservableCollection<CheckedListItem<MusicBeePlaylist>>();
             SpotifyPlaylists = new ObservableCollection<CheckedListItem<SpotifyPlaylist>>();
             LibrarySearchResults = new ObservableCollection<MusicBeeSongSearch>();
-
-            FindResultsFromLibrary.ItemsSource = LibrarySearchResults;
-            FindResultsFromLibrary.SetBinding(ListBox.SelectedItemProperty, new Binding("LibrarySearchResultsSelected") { Source = this, Mode = BindingMode.TwoWay });
+            SpotifySongSearchResults = new ObservableCollection<FullTrack>();
 
             MusicBee = new MusicBeeSyncHelper(apiInterface);
             RefreshMusicBeePlaylists();
@@ -67,6 +71,15 @@ namespace MBSyncToServiceUI
             Action<string> log = (s) => Dispatcher.Invoke(() => { Log(s); });
             Spotify = new SpotifySyncHelper(log, MusicBee);
 
+            SongConferenceListBox.ItemsSource = Spotify.PopulatedSongs;
+            SongConferenceListBox.SetBinding(ListBox.SelectedItemProperty, new Binding("PopulatedSongSelected") { Source = this, Mode = BindingMode.TwoWay });
+
+            FindResultsFromLibrary.ItemsSource = LibrarySearchResults;
+            FindResultsFromLibrary.SetBinding(ListBox.SelectedItemProperty, new Binding("LibrarySearchResultsSelected") { Source = this, Mode = BindingMode.TwoWay });
+
+            FindResultsFromSpotify.ItemsSource = SpotifySongSearchResults;
+            FindResultsFromSpotify.SetBinding(ListBox.SelectedItemProperty, new Binding("SpotifySongSearchResultsSelected") { Source = this, Mode = BindingMode.TwoWay });
+            
             ClearPanelsVisibility();
         }
 
@@ -139,18 +152,26 @@ namespace MBSyncToServiceUI
         {
             ClearPanelsVisibility();
         }
-        private void ButtonContinueToSinc_Click(object sender, RoutedEventArgs e)
+        private async void ButtonContinueToSinc_Click(object sender, RoutedEventArgs e)
         {
-            _ = SpotifyToMbSavePopulatedList();
+            if (SyncToService)
+            {
+                await MbToSpotifySavePopulatedList();
+            }
+            else
+            {
+                await SpotifyToMbSavePopulatedList();
+            }
+
+            ClearPanelsVisibility();
         }
 
         private void ClearPanelsVisibility()
         {
             FirstSectionPanel.Visibility = Visibility.Visible;
-            SecondSectionPanelToMB.Visibility = Visibility.Hidden;
-            SecondSectionPanelToSpotify.Visibility = Visibility.Hidden;
+            SecondSectionPanel.Visibility = Visibility.Hidden;
 
-            MBSongConferenceListBox.ItemsSource = null;
+            SongConferenceListBox.Items.Refresh();
         }
 
         private async void SpotifySyncButton_Click(object sender, RoutedEventArgs e)
@@ -159,43 +180,57 @@ namespace MBSyncToServiceUI
             Log($"Starting sync {direction} Spotify...");
             SpotifySelectAllButton.IsEnabled = false;
             SpotifySyncButton.IsEnabled = false;
+            BtnBackSelection.IsEnabled = false;
+            BtnContinueSync.IsEnabled = false;
+            SongSearchBox.IsEnabled = false;
 
-            int toSyncCount = (SyncToService ? GetMusicBeePlaylistsToSync().Count : GetSpotifyPlaylistsToSync().Count);
-
-            if (toSyncCount == 1)
+            try
             {
-                FirstSectionPanel.Visibility = Visibility.Hidden;
-                if (SyncToService)
+                int toSyncCount = (SyncToService ? GetMusicBeePlaylistsToSync().Count : GetSpotifyPlaylistsToSync().Count);
+
+                if (toSyncCount == 1)
                 {
-                    SecondSectionPanelToSpotify.Visibility = Visibility.Visible;
+                    FirstSectionPanel.Visibility = Visibility.Hidden;
+                    SecondSectionPanel.Visibility = Visibility.Visible;
+                    ServiceTypeLabel.Content = SyncToService ? "Sync MB playlist to Spotify" : "Sync Spotify playlist to MB";
+                    SpotifySearchHint.Visibility = SyncToService ? Visibility.Visible : Visibility.Hidden;
+                    SongConferenceListBox.Items.Refresh();
+
+                    if (SyncToService)
+                    {
+                        await MbToSpotifyPopulateSongsOfSelectedPlaylist();
+                    }
+                    else
+                    {
+                        await SpotifyToMbPopulateSongsOfSelectedPlaylist();
+                    }
+                }
+                else if (toSyncCount > 1)
+                {
+                    if (MessageBox.Show($"Are you really sure that you want to sync {toSyncCount} playlists automatic?", Title, MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
+                    {
+                        await SpotifySyncMultiplePlaylists();
+                        Log($"Finished sync {direction} Spotify.");
+                    }
                 }
                 else
                 {
-                    SecondSectionPanelToMB.Visibility = Visibility.Visible;
-                    await SpotifyToMbPopulateSongsOfSelectedPlaylist();
-                    Log($"Finished to populate the list.");
+                    Log("Nothing done, select one playlist or more.");
                 }
-            }
-            else if(toSyncCount > 1)
-            {
-                if (MessageBox.Show($"Are you really sure that you want to sync {toSyncCount} playlists automatic?", Title, MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
-                {
-                    await SpotifySyncMultiplePlaylists();
-                    Log($"Finished sync {direction} Spotify.");
-                }
-            }
-            else
-            {
-                Log("Nothing done, select one playlist or more.");
-            }
 
-            SpotifySelectAllButton.IsEnabled = true;
-            SpotifySyncButton.IsEnabled = true;            
+            }
+            finally
+            {
+                SpotifySelectAllButton.IsEnabled = true;
+                SpotifySyncButton.IsEnabled = true;
+                BtnBackSelection.IsEnabled = true;
+                BtnContinueSync.IsEnabled = true;
+                SongSearchBox.IsEnabled = true;
+            }
         }
 
         private async Task SpotifyToMbPopulateSongsOfSelectedPlaylist()
         {
-            MBSongConferenceListBox.ItemsSource = null;
             try
             {
                 var spotifyPlaylistsToSync = GetSpotifyPlaylistsToSync().First();
@@ -203,8 +238,7 @@ namespace MBSyncToServiceUI
                 Spotify.PopulateSpotifyPlaylist = spotifyPlaylistsToSync;
                 await Spotify.PopulateMbPlaylistSongsFromSpotifyPlaylist();
 
-                MBSongConferenceListBox.ItemsSource = Spotify.PopulatedSongs;
-                MBSongConferenceListBox.SetBinding(ListBox.SelectedItemProperty, new Binding("PopulatedSongFromSpotifySelected") { Source = this, Mode = BindingMode.TwoWay });
+                SongConferenceListBox.Items.Refresh();
 
                 if (Spotify.PopulateErrors.Count > 0)
                 {
@@ -218,7 +252,7 @@ namespace MBSyncToServiceUI
                         });
 
                     Log(errors.ToString());
-                    Log("See errors above");
+                    Log("Populated songs from Spotify with errors above");
                 }
                 else
                 {
@@ -243,6 +277,67 @@ namespace MBSyncToServiceUI
 
                 await Spotify.SaveMbPlaylistPopulatedFromSpotifyPlaylist();
                 Log($"Successfully saved playlist from Spotify");
+            }
+            catch (Exception ex)
+            {
+                Log(ex.Message);
+            }
+        }
+
+        private async Task MbToSpotifySavePopulatedList()
+        {
+            try
+            {
+                if (Spotify.PopulatedSongs.Where(w => w.Checked).Count() == 0)
+                {
+                    MessageBox.Show("No songs selected to save", Title, MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                SyncToSpotifySettings settings = new SyncToSpotifySettings()
+                {
+                    IncludeFoldersInPlaylistName = IncludeFolders,
+                    IncludeZAtStartOfDatePlaylistName = IncludeZ,
+                };
+
+                await Spotify.SaveSpotifyPlaylistPopulatedFromMbPlaylist(settings);
+                Log($"Successfully saved playlist to Spotify");
+            }
+            catch (Exception ex)
+            {
+                Log(ex.Message);
+            }
+        }
+
+        private async Task MbToSpotifyPopulateSongsOfSelectedPlaylist()
+        {
+            try
+            {
+                var MbPlaylistsToSync = GetMusicBeePlaylistsToSync().First();
+
+                Spotify.PopulateMusicBeePlaylist = MbPlaylistsToSync;
+                await Spotify.PopulateSpotifyPlaylistSongsFromMbPlaylist();
+
+                SongConferenceListBox.Items.Refresh();
+
+                if (Spotify.PopulateErrors.Count > 0)
+                {
+                    var errors = Spotify
+                        .PopulateErrors
+                        .Select(s => s.GetMessage())
+                        .Aggregate(new StringBuilder(), (sb, s) =>
+                        {
+                            sb.AppendLine(s);
+                            return sb;
+                        });
+
+                    Log(errors.ToString());
+                    Log("Populated songs from MusicBee playlist with errors above");
+                }
+                else
+                {
+                    Log($"Successfully populated songs from MusicBee playlist");
+                }
             }
             catch (Exception ex)
             {
@@ -350,15 +445,15 @@ namespace MBSyncToServiceUI
         #endregion      
 
 
-        private void ChangePopuplatedSongFromSpotifyLibraryRelated(MusicBeeSongSearch changeTo)
+        private void ChangePopuplatedSongWithMBLibraryRelated(MusicBeeSongSearch changeTo)
         {
-            if (PopulatedSongFromSpotifySelected != null)
+            if (PopulatedSongSelected != null)
             {
-                PopulatedSongFromSpotifySelected.MbSong = changeTo.Song;
-                PopulatedSongFromSpotifySelected.Checked = true;
+                PopulatedSongSelected.MbSong = changeTo.Song;
+                PopulatedSongSelected.Checked = true;
 
-                MBSongConferenceListBox.Items.Refresh();
-            }    
+                SongConferenceListBox.Items.Refresh();
+            }
         }
 
         private void SearchOnLibrary(string text)
@@ -380,6 +475,8 @@ namespace MBSyncToServiceUI
 
                 foreach (var result in results)
                     LibrarySearchResults.Add(result);
+
+                LibrarySearchResultsSelected = LibrarySearchResults.FirstOrDefault();
             }
             catch 
             {
@@ -390,16 +487,44 @@ namespace MBSyncToServiceUI
                 FindResultsFromLibrary.Visibility = LibrarySearchResults.Any() ? Visibility.Visible : Visibility.Hidden;
             }
         }
-        private void ClearFindResultsFromLibrary()
+        private void ClearSearchResults()
         {
-            FindResultsFromLibrary.Visibility = Visibility.Hidden;
-            LibrarySearchResultsSelected = null;
-            LibrarySearchResults.Clear();
+            if (SyncToService)
+            {
+                FindResultsFromSpotify.Visibility = Visibility.Hidden;
+                SpotifySongSearchResultsSelected = null;
+                SpotifySongSearchResults.Clear();
+            }
+            else
+            {
+                FindResultsFromLibrary.Visibility = Visibility.Hidden;
+                LibrarySearchResultsSelected = null;
+                LibrarySearchResults.Clear();
+            }
+        }
+        private void UseFirstSearchResult()
+        {
+            if (SyncToService)
+            {
+                if (SpotifySongSearchResults.Any())
+                {
+                    var changeTo = SpotifySongSearchResults.First();
+                    ChangePopuplatedSongWithSpotifySongRelated(changeTo);
+                }
+            }
+            else
+            {
+                if (LibrarySearchResults.Any())
+                {
+                    var changeTo = LibrarySearchResults.First();
+                    ChangePopuplatedSongWithMBLibraryRelated(changeTo);
+                }
+            }
         }
 
         private DispatcherTimer searchLibraryDelayTimer = null;
 
-        private void LibrarySearchBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        private void SongSearchBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
         {
             if (searchLibraryDelayTimer == null)
             {
@@ -408,7 +533,15 @@ namespace MBSyncToServiceUI
                 searchLibraryDelayTimer.Tick += new EventHandler((s, ee) =>
                 {
                     searchLibraryDelayTimer.Stop();
-                    SearchOnLibrary(LibrarySearchBox.Text);
+
+                    if (SyncToService)
+                    {
+                        _ = SearchOnSpotify(SongSearchBox.Text);
+                    }
+                    else
+                    {
+                        SearchOnLibrary(SongSearchBox.Text);
+                    }
                 });
             }
 
@@ -416,39 +549,52 @@ namespace MBSyncToServiceUI
             searchLibraryDelayTimer.Start();
         }
 
-        private void LibrarySearchBox_PreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        private void SongSearchBox_PreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (e.Key == System.Windows.Input.Key.Enter)
             {
                 e.Handled = true;
 
-                if (LibrarySearchResults.Any())
-                {
-                    var changeTo = LibrarySearchResults.First();
-                    ChangePopuplatedSongFromSpotifyLibraryRelated(changeTo);
-                }
-
-                ClearFindResultsFromLibrary();
+                UseFirstSearchResult();
+                ClearSearchResults();
             }
             else if (e.Key == System.Windows.Input.Key.Escape)
             {
                 e.Handled = true;
-                ClearFindResultsFromLibrary();
-                LibrarySearchBox.Text = "";
+                ClearSearchResults();
+                SongSearchBox.Text = "";
             }
             else if (e.Key == System.Windows.Input.Key.Down)
             {
                 e.Handled = true;
-                if (FindResultsFromLibrary.IsVisible)
+
+                if (SyncToService)
                 {
-                    if (LibrarySearchResults.Count > 1)
+                    if (FindResultsFromSpotify.IsVisible)
                     {
-                        FindResultsFromLibrary.SelectedIndex = 1;
-                        FindResultsFromLibrary.UpdateLayout();
-                        FindResultsFromLibrary.Focus();
+                        if (SpotifySongSearchResults.Count > 1)
+                        {
+                            FindResultsFromSpotify.SelectedIndex = 1;
+                            FindResultsFromSpotify.UpdateLayout();
+                            FindResultsFromSpotify.Focus();
+                        }
+                        else
+                            FindResultsFromSpotify.Focus();
                     }
-                    else
-                        FindResultsFromLibrary.Focus();
+                }
+                else
+                {
+                    if (FindResultsFromLibrary.IsVisible)
+                    {
+                        if (LibrarySearchResults.Count > 1)
+                        {
+                            FindResultsFromLibrary.SelectedIndex = 1;
+                            FindResultsFromLibrary.UpdateLayout();
+                            FindResultsFromLibrary.Focus();
+                        }
+                        else
+                            FindResultsFromLibrary.Focus();
+                    }
                 }
             }
         }
@@ -458,16 +604,93 @@ namespace MBSyncToServiceUI
             if (e.Key == System.Windows.Input.Key.Escape)
             {
                 e.Handled = true;
-                ClearFindResultsFromLibrary();
+                ClearSearchResults();
             }
             else if (e.Key == System.Windows.Input.Key.Enter)
             {
                 e.Handled = true;
                 
                 if (LibrarySearchResultsSelected != null)
-                    ChangePopuplatedSongFromSpotifyLibraryRelated(LibrarySearchResultsSelected);
+                    ChangePopuplatedSongWithMBLibraryRelated(LibrarySearchResultsSelected);
 
-                ClearFindResultsFromLibrary();
+                ClearSearchResults();
+            }
+        }
+
+        private void FindResultsFromLibrary_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (LibrarySearchResultsSelected != null)
+            {
+                ChangePopuplatedSongWithMBLibraryRelated(LibrarySearchResultsSelected);
+                ClearSearchResults();
+            }
+        }
+
+
+        private void ChangePopuplatedSongWithSpotifySongRelated(FullTrack changeTo)
+        {
+            if (PopulatedSongSelected != null)
+            {
+                PopulatedSongSelected.SpotifySong = changeTo;
+                PopulatedSongSelected.Checked = true;
+
+                SongConferenceListBox.Items.Refresh();
+            }
+        }
+
+        private async Task SearchOnSpotify(string text)
+        {
+            SpotifySongSearchResults.Clear();
+
+            try
+            {
+                text = text.Trim();
+                string[] query = text.Split(new[] { " - " }, StringSplitOptions.None);
+                
+                if (query.Length != 2)
+                    return;
+
+                var results = await Spotify.FindSongsInSpotifyDatabase(query[0], query[1]);
+
+                foreach (var result in results.Take(10))
+                    SpotifySongSearchResults.Add(result);
+
+                SpotifySongSearchResultsSelected = SpotifySongSearchResults.FirstOrDefault();
+            }
+            catch
+            {
+                Log("Something goes wrong at search.");
+            }
+            finally
+            {
+                FindResultsFromSpotify.Visibility = SpotifySongSearchResults.Any() ? Visibility.Visible : Visibility.Hidden;
+            }
+        }
+
+        private void FindResultsFromSpotify_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (SpotifySongSearchResultsSelected != null)
+            {
+                ChangePopuplatedSongWithSpotifySongRelated(SpotifySongSearchResultsSelected);
+                ClearSearchResults();
+            }
+        }
+
+        private void FindResultsFromSpotify_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                e.Handled = true;
+                ClearSearchResults();
+            }
+            else if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                e.Handled = true;
+
+                if (SpotifySongSearchResultsSelected != null)
+                    ChangePopuplatedSongWithSpotifySongRelated(SpotifySongSearchResultsSelected);
+
+                ClearSearchResults();
             }
         }
     }


### PR DESCRIPTION
* Removed tabbed style (don't need anymore, it's only to spotify service)
* Getting colors from skin
* Resizing allowed
* Refactored the match songs algorithm allowing to "pause" between synchronization
* When only one playlist selected, a new panel to confirm track by track will appear
* In the same panel will have an individual search for unmatched songs (Spotify to MB and vice versa)

Done in rush to test in my daily use, I suggest doing the same or to release a beta version.

![image](https://github.com/user-attachments/assets/bdd5444a-a6d9-424d-9dcd-99109323ce56)